### PR TITLE
Proxy support

### DIFF
--- a/test/webserver.erl
+++ b/test/webserver.erl
@@ -118,8 +118,8 @@ listen(ssl) ->
         {active, false},
         {ip, {127,0,0,1}},
         {verify, verify_none},
-        {keyfile, "../test/key.pem"},
-        {certfile, "../test/crt.pem"}
+        {keyfile, "./test/key.pem"},
+        {certfile, "./test/crt.pem"}
     ],
     {ok, LS} = ssl:listen(0, Opts),
     LS;


### PR DESCRIPTION
I am adding the `{proxy, ProxyUrl}` option in the `request` function.
It will send a request to the `ProxyUrl` with the absolute requested URL in the HTTP request line.

We need it to support fault injections on the HTTP level that are proxied via Envoy Proxy.