### PR TITLE
Add support for multiple pools for the same url

### DIFF
--- a/src/dlhttpc.erl
+++ b/src/dlhttpc.erl
@@ -612,6 +612,8 @@ verify_options([{proxy, ProxyURL} | Options], Errors) when is_list(ProxyURL) ->
   verify_options(Options, Errors);
 verify_options([{stream_to, Pid} | Options], Errors) when is_pid(Pid) ->
     verify_options(Options, Errors);
+verify_options([{pool_name, PoolName} | Options], Errors) when is_atom(PoolName) ->
+    verify_options(Options, Errors);
 verify_options([Option | Options], Errors) ->
     verify_options(Options, [Option | Errors]);
 verify_options([], []) ->

--- a/src/dlhttpc_client.erl
+++ b/src/dlhttpc_client.erl
@@ -112,12 +112,13 @@ execute(ReqId, From, Host, Port, Ssl, Path, Method, Hdrs, Body, Options) ->
         Hdrs, Host, Port, Body, PartialUpload),
     ConnectOptions = proplists:get_value(connect_options, Options, []),
     SockOpts = [binary, {packet, http}, {active, false} | ConnectOptions],
+    PoolName = proplists:get_value(pool_name, Options, default),
     {SocketRef, Socket} =
         case MaxConnections of
             bypass ->
                 {undefined, undefined};
             Number when is_integer(Number) ->
-                case dlhttpc_disp:checkout(Host, Port, Ssl, MaxConnections, ConnectionTimeout, SockOpts, CheckoutRetry) of
+                case dlhttpc_disp:checkout(Host, Port, Ssl, MaxConnections, ConnectionTimeout, SockOpts, CheckoutRetry, PoolName) of
                     {ok, Ref, S} -> {Ref, S}; % Re-using HTTP/1.1 connections
                     {error, CheckoutErr} -> throw(CheckoutErr)
                 end

--- a/test/dlhttpc_tests.erl
+++ b/test/dlhttpc_tests.erl
@@ -152,6 +152,7 @@ tcp_test_() ->
                 ?_test(close_connection()),
                 ?_test(proxy_request()),
                 ?_test(proxy_request_with_port()),
+                ?_test(non_default_pool_name_request()),
                 ?_test(message_queue())
             ]}
     }.
@@ -634,6 +635,13 @@ proxy_request_with_port() ->
     ?assertEqual(<<?DEFAULT_STRING>>, body(Response)),
     ?assertEqual("http://httpbin.org:80/get",
         dlhttpc_lib:header_value("x-test-orig-uri", headers(Response))).
+
+non_default_pool_name_request() ->
+    Port = start(gen_tcp, [fun simple_response/5]),
+    URL = url(Port,"/simple"),
+    {ok, Response} = dlhttpc:request(URL, "GET", [], "", 1000, [{pool_name, non_default}]),
+    ?assertEqual({200, "OK"}, status(Response)),
+    ?assertEqual(<<?DEFAULT_STRING>>, body(Response)).
 
 ssl_get() ->
     Port = start(ssl, [fun simple_response/5]),


### PR DESCRIPTION
## Context

We want to be more granular with HTTP connection pools for the same URL.  For example, we are going to have statsig exposed by the main backend via internal endpoints, the same one that returns us user info, and handles payment requests. So if any of operations saturate the pool we won't be able to fetch statsig config with kill switches that can help us mitigate such scenario.

Another use case could be separating different independent dynamodb calls.